### PR TITLE
Up-stream: Fixes #162: input queue tracks number of elements in all queues to bound the size

### DIFF
--- a/calamari_ocr/ocr/datasets/input_dataset.py
+++ b/calamari_ocr/ocr/datasets/input_dataset.py
@@ -11,6 +11,9 @@ from calamari_ocr.utils.multiprocessing import tqdm_wrapper
 from abc import ABC, abstractmethod
 import logging
 
+from .queue_helper import MaxElementsQueuer
+from ..augmentation.dataaugmentationparams import DataAugmentationAmount, DataAugmentationAmountReference
+
 logger = logging.getLogger(__name__)
 
 
@@ -257,7 +260,9 @@ class StreamingInputDataset(InputDataset):
     def __enter__(self):
         super().__enter__()
         # create all tasks and queues
-        self.data_input_queue = self.mp_context.JoinableQueue(self.processes * 4)
+        self.max_queuer = MaxElementsQueuer(self.processes * 4, ctx=self.mp_context)
+        self.data_input_queue = self.max_queuer.input_queue
+        self.ordered_output_queue = self.max_queuer.output_queue
         self.unordered_output_queue = self.mp_context.JoinableQueue()
 
         self.data_processing_tasks = [
@@ -277,7 +282,6 @@ class StreamingInputDataset(InputDataset):
 
         self.data_generator = self.dataset.create_generator(self.mp_context, self.data_input_queue)
         self.data_generator.start()
-        self.ordered_output_queue = self.mp_context.JoinableQueue(self.processes * 4)
         self.data_ordering = OrderedQueueTask(self.unordered_output_queue, self.ordered_output_queue, self.mp_context)
         self.data_ordering.start()
 

--- a/calamari_ocr/ocr/datasets/queue_helper.py
+++ b/calamari_ocr/ocr/datasets/queue_helper.py
@@ -1,0 +1,48 @@
+from multiprocessing.queues import JoinableQueue
+from queue import Full
+
+
+class FeedBackJoinableQueue(JoinableQueue):
+    def __init__(self, maxsize, max_feed, ctx):
+        super().__init__(maxsize=maxsize, ctx=ctx)
+        self.max_feed_queue = max_feed
+
+    def get(self, block=True, timeout=None):
+        r = super().get(block, timeout)
+        self.max_feed_queue.job_finished()
+        return r
+
+
+class MaxFeedJoinablQueue(JoinableQueue):
+    def __init__(self, maxsize, ctx):
+        super().__init__(maxsize=maxsize, ctx=ctx)
+        self._cursize = ctx.Value('i', 0)
+
+    def __getstate__(self):
+        return JoinableQueue.__getstate__(self) + (self._cursize, )
+
+    def __setstate__(self, state):
+        JoinableQueue.__setstate__(self, state[:-1])
+        self._cursize, = state[-1:]
+
+    def job_finished(self):
+        with self._cond:
+            if self._cursize.value > 0:
+                self._cursize.value -= 1
+
+    def put(self, obj, block=True, timeout=None):
+        with self._cond:
+            if self._cursize.value >= self._maxsize:
+                raise Full
+            self._cursize.value += 1
+
+        return super().put(obj, block, timeout)
+
+
+class MaxElementsQueuer:
+    def __init__(self, maxsize, ctx):
+        # the input queue tracks how many elements are queued and only enqueues new elements if the number of elements
+        # in all queues is smaller than maxsize
+        self.input_queue = MaxFeedJoinablQueue(maxsize, ctx)
+        self.output_queue = FeedBackJoinableQueue(maxsize, self.input_queue, ctx)
+


### PR DESCRIPTION
Cherrypick from Upstream